### PR TITLE
Add copy to clipboard for tokens in HTML template

### DIFF
--- a/pkg/connect/authCodeFlow/templates.go
+++ b/pkg/connect/authCodeFlow/templates.go
@@ -19,22 +19,82 @@ func TokenResultView() string {
 				font-family: sans-serif;
 				margin: 3em;
 			}
+
+			.tooltip {
+				position: relative;
+				display: inline-block;
+			}
+
+			.tooltip .tooltiptext {
+				visibility: hidden;
+				width: 140px;
+				background-color: #555;
+				color: #fff;
+				text-align: center;
+				border-radius: 6px;
+				padding: 5px;
+				position: absolute;
+				z-index: 1;
+				bottom: 150%;
+				left: 50%;
+				margin-left: -75px;
+				opacity: 0;
+				transition: opacity 0.3s;
+			}
+
+			.tooltip .tooltiptext::after {
+				content: "";
+				position: absolute;
+				top: 100%;
+				left: 50%;
+				margin-left: -5px;
+				border-width: 5px;
+				border-style: solid;
+				border-color: #555 transparent transparent transparent;
+			}
+
+			.tooltip:hover .tooltiptext {
+				visibility: visible;
+				opacity: 1;
+			}
 		</style>
 	</head>
 	<body>
 		<h3>OpenId Connect credentials</h3>
 		<p>Authority: {{.Authority}}</p>
-		<ul>
-			<li>
-				access token: {{.AccessToken}}
-			</li>
-			<li>
-				refresh token: {{.RefreshToken}}
-			</li>
-			<li>
-				identity token: {{.IdToken}}
-			</li>
-		</ul>
+		<div>
+			<strong>Access token:</strong>
+			<div class="tooltip">
+			<button onclick="copyTextBoxValue('access_token', 'access_token_tooltip')" onmouseout="outFunc('access_token_tooltip')">
+				<span class="tooltiptext" id="access_token_tooltip">Copy to clipboard</span>
+				Copy text
+			</button>
+			</div>
+			<br/>
+			<textarea id="access_token" rows="4" cols="70">{{.AccessToken}}</textarea>
+		</div>
+		<div>
+			<strong>Refresh token:</strong>
+			<div class="tooltip">
+			<button onclick="copyTextBoxValue('refresh_token', 'refresh_token_tooltip')" onmouseout="outFunc('refresh_token_tooltip')">
+				<span class="tooltiptext" id="refresh_token_tooltip">Copy to clipboard</span>
+				Copy text
+			</button>
+			</div>
+			<br/>
+			<textarea id="refresh_token" rows="4" cols="70">{{.RefreshToken}}</textarea>
+		</div>
+		<div>
+			<strong>Identity token:</strong>
+			<div class="tooltip">
+			<button onclick="copyTextBoxValue('id_token', 'id_token_tooltip')" onmouseout="outFunc('id_token_tooltip')">
+				<span class="tooltiptext" id="id_token_tooltip">Copy to clipboard</span>
+				Copy text
+			</button>
+			</div>
+			<br />
+			<textarea id="id_token" rows="4" cols="70">{{.IdToken}}</textarea>
+		</div>
 		
 		<h3>ID Token Claims</h3>
 		
@@ -43,6 +103,22 @@ func TokenResultView() string {
 		{{ end }}
 		
 		<p>✅ You can close this window now.</p>
+		<script>
+			function copyTextBoxValue(textAreaId, tooltipId) {
+				var copyText = document.getElementById(textAreaId);
+				copyText.select();
+				copyText.setSelectionRange(0, 99999);
+				document.execCommand("copy");
+
+				var tooltip = document.getElementById(tooltipId);
+				tooltip.innerHTML = "Copied: " + copyText.value;
+			}
+
+			function outFunc(tooltipId) {
+				var tooltip = document.getElementById(tooltipId);
+				tooltip.innerHTML = "Copy to clipboard";
+			}
+		</script>
 	</body>
 </html>
 `


### PR DESCRIPTION
The current template makes it unnecessarily difficult (P.I.T.A.) to select the token and copy it. The long length of the tokens, and their physical spacing makes it easy to select too few or too many characters / lines. 

This PR adds copy to clipboard functionality in the HTML template so that the user can easily copy the tokens to the clipboard. 
Example:
![image](https://user-images.githubusercontent.com/145854/87951839-63bf8100-caa9-11ea-939d-12fd49f9da91.png)
