### PR TITLE
Enable custom servers with OAuth application id in url path.

### DIFF
--- a/pkg/oidc/discovery.go
+++ b/pkg/oidc/discovery.go
@@ -18,7 +18,7 @@ func GetSchemeAndHost(urlString string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host), nil
+	return fmt.Sprintf("%s://%s%s", parsed.Scheme, parsed.Host, parsed.Path), nil
 }
 
 


### PR DESCRIPTION
Please note some providers like for example Okta allows to create custom authorisation servers like described here 
https://developer.okta.com/docs/concepts/auth-servers/
This allows to create custom servers for apps with separate urls based on schema.
"
OpenID: https://${yourOktaDomain}/oauth2/<server id>/.well-known/openid-configuration
OAuth: https://${yourOktaDomain}/oauth2/<server id>/.well-known/oauth-authorization-server
"

The change adds path component to discovery url for endpoints. Tested with generic hostname base url and this custom based.
